### PR TITLE
feat(gp): new feature `gp.NewLogger()`; and fix `stack overflow` bug

### DIFF
--- a/go-print/goprint.go
+++ b/go-print/goprint.go
@@ -72,7 +72,7 @@ func (f *Formatter) ToString(data any) string {
 }
 
 func (f *Formatter) toString(data any, indents []int) string {
-	// BUG: 前几天测试遇到panic，可能是什么地方遍历对象没考虑private
+	// BUG: 有时候报stack overflow，怀疑是有结构体循环引用自己导致无限递归
 	value := reflect.ValueOf(data)
 	switch value.Kind() {
 	case reflect.String:

--- a/go-print/goprint.go
+++ b/go-print/goprint.go
@@ -262,11 +262,11 @@ func (f *Formatter) funcOutTypeString(type_ reflect.Type) string {
 
 func (f *Formatter) structToString(value reflect.Value, indents []int) string {
 	type_ := value.Type()
-	var fields []reflect.StructField
+	var fields map[int]reflect.StructField
 	for i := 0; i < value.NumField(); i++ {
 		field := type_.Field(i)
 		if field.IsExported() {
-			fields = append(fields, field)
+			fields[i] = field
 		}
 	}
 	length := len(fields)
@@ -277,13 +277,15 @@ func (f *Formatter) structToString(value reflect.Value, indents []int) string {
 	if length > 0 {
 		indents = append(indents, f.StructIndent)
 		appendIndent(&sb, f.StructIndent, indents, true, f.BracketColor)
+		cnt := 0
 		for i, field := range fields {
 			sb.WriteString(field.Name)
 			sb.WriteString("=")
 			sb.WriteString(f.toString(value.Field(i).Interface(), indents))
-			if i < length-1 {
+			if cnt < length-1 {
 				appendIndent(&sb, f.StructIndent, indents, true, f.BracketColor)
 			}
+			cnt++
 		}
 		indents = indents[:len(indents)-1]
 		appendIndent(&sb, f.StructIndent, indents, false, f.BracketColor)

--- a/go-print/goprint.go
+++ b/go-print/goprint.go
@@ -34,10 +34,19 @@ type Formatter struct {
 	// If `len(data) > MapDisplayNum`, extra parts are shown as ellipsis.
 	MapDisplayNum int
 	BracketColor  bool
+	// Determines whether to display strings with quotes.
+	//
+	// When the string is nested (e.g., within a slice, struct, or similar composite),
+	// it will always appear enclosed in quotes, regardless of the value of StrQuote.
+	StrQuote bool
 }
 
 var DefaultFormatter = Formatter{
-	StructIndent: 2, ListDisplayNum: 100, MapDisplayNum: 100, BracketColor: true,
+	StructIndent:   2,
+	ListDisplayNum: 100,
+	MapDisplayNum:  100,
+	BracketColor:   true,
+	StrQuote:       true,
 }
 
 var (
@@ -76,7 +85,11 @@ func (f *Formatter) toString(data any, indents []int) string {
 	value := reflect.ValueOf(data)
 	switch value.Kind() {
 	case reflect.String:
-		return fmt.Sprintf("%q", data)
+		if f.StrQuote && len(indents) != 0 {
+			return fmt.Sprintf("%q", data)
+		} else {
+			return fmt.Sprint(data)
+		}
 	case reflect.Pointer:
 		if value.IsNil() {
 			return fmt.Sprintf("<%s nil>", f.typeToString(value.Type()))

--- a/go-print/goprint.go
+++ b/go-print/goprint.go
@@ -42,7 +42,6 @@ type Formatter struct {
 }
 
 var DefaultFormatter = Formatter{
-	StructIndent:   2,
 	ListDisplayNum: 100,
 	MapDisplayNum:  100,
 	BracketColor:   true,
@@ -275,7 +274,7 @@ func (f *Formatter) funcOutTypeString(type_ reflect.Type) string {
 
 func (f *Formatter) structToString(value reflect.Value, indents []int) string {
 	type_ := value.Type()
-	var fields map[int]reflect.StructField
+	var fields = make(map[int]reflect.StructField)
 	for i := 0; i < value.NumField(); i++ {
 		field := type_.Field(i)
 		if field.IsExported() {

--- a/go-print/goprint.go
+++ b/go-print/goprint.go
@@ -36,7 +36,7 @@ type Formatter struct {
 	BracketColor  bool
 }
 
-var Default = Formatter{
+var DefaultFormatter = Formatter{
 	StructIndent: 2, ListDisplayNum: 100, MapDisplayNum: 100, BracketColor: true,
 }
 
@@ -64,7 +64,7 @@ var (
 )
 
 func ToString(data any) string {
-	return Default.ToString(data)
+	return DefaultFormatter.ToString(data)
 }
 
 func (f *Formatter) ToString(data any) string {
@@ -72,6 +72,7 @@ func (f *Formatter) ToString(data any) string {
 }
 
 func (f *Formatter) toString(data any, indents []int) string {
+	// BUG: 前几天测试遇到panic，可能是什么地方遍历对象没考虑private
 	value := reflect.ValueOf(data)
 	switch value.Kind() {
 	case reflect.String:

--- a/go-print/goprint.go
+++ b/go-print/goprint.go
@@ -256,7 +256,10 @@ func (f *Formatter) mapToString(value reflect.Value, ctx gpfContext) string {
 		ctx.Indents = ctx.Indents[:len(ctx.Indents)-1]
 		appendIndent(&sb, f.MapIndent, ctx.Indents, false, f.BracketColor)
 	} else if length > 0 { // cannot show items, but actually has items
-		sb.WriteString(" ...")
+		if f.MapShowAsTag {
+			sb.WriteRune(' ')
+		}
+		sb.WriteString("...")
 	}
 	if f.MapShowAsTag {
 		appendColoredString(&sb, ">", len(ctx.Indents), f.BracketColor, true)

--- a/go-print/logger.go
+++ b/go-print/logger.go
@@ -19,9 +19,6 @@ func NewLogger(pkgName string) *Logger {
 	}
 	logger.SetFlags(log.Ldate | log.Lmicroseconds | log.Lshortfile)
 
-	// TODO: 在Println等情况真正用上gs.Formatter
-	logger.formatter = &DefaultFormatter
-
 	return logger
 }
 
@@ -30,7 +27,7 @@ func (l *Logger) UseFormatter(formatter *Formatter) *Logger {
 	return l
 }
 
-func (l *Logger) UseStdFormatter() *Logger {
-	l.formatter = nil
-	return l
+func (l *Logger) UseGpFormatter() *Logger {
+	// TODO: 在Println等情况真正用上gs.Formatter
+	return l.UseFormatter(&DefaultFormatter)
 }

--- a/go-print/logger.go
+++ b/go-print/logger.go
@@ -29,7 +29,7 @@ func (l *Logger) UseFormatter(formatter *Formatter) *Logger {
 	return l
 }
 
-func (l *Logger) UseStdFormatter() *Logger {
+func (l *Logger) ClearFormatter() *Logger {
 	return l.UseFormatter(nil)
 }
 

--- a/go-print/logger.go
+++ b/go-print/logger.go
@@ -1,0 +1,36 @@
+package gp
+
+import (
+	"log"
+	"os"
+)
+
+type Logger struct {
+	log.Logger
+
+	formatter *Formatter
+}
+
+func NewLogger(pkgName string) *Logger {
+	logger := new(Logger)
+	logger.SetOutput(os.Stderr)
+	if pkgName != "" {
+		logger.SetPrefix("[" + pkgName + "] ")
+	}
+	logger.SetFlags(log.Ldate | log.Lmicroseconds | log.Lshortfile)
+
+	// TODO: 在Println等情况真正用上gs.Formatter
+	logger.formatter = &DefaultFormatter
+
+	return logger
+}
+
+func (l *Logger) UseFormatter(formatter *Formatter) *Logger {
+	l.formatter = formatter
+	return l
+}
+
+func (l *Logger) UseStdFormatter() *Logger {
+	l.formatter = nil
+	return l
+}

--- a/go-print/logger.go
+++ b/go-print/logger.go
@@ -28,6 +28,50 @@ func (l *Logger) UseFormatter(formatter *Formatter) *Logger {
 }
 
 func (l *Logger) UseGpFormatter() *Logger {
-	// TODO: 在Println等情况真正用上gs.Formatter
 	return l.UseFormatter(&DefaultFormatter)
+}
+
+func (l *Logger) convertArgs(v []any) []any {
+	if l.formatter != nil {
+		for i, vv := range v {
+			v[i] = l.formatter.ToString(vv)
+		}
+	}
+	return v
+}
+
+func (l *Logger) Print(v ...any) {
+	l.Logger.Print(l.convertArgs(v)...)
+}
+
+func (l *Logger) Println(v ...any) {
+	l.Logger.Println(l.convertArgs(v)...)
+}
+
+func (l *Logger) Printf(format string, v ...any) {
+	l.Logger.Printf(format, l.convertArgs(v)...)
+}
+
+func (l *Logger) Fatal(v ...any) {
+	l.Logger.Fatal(l.convertArgs(v)...)
+}
+
+func (l *Logger) Fatalln(v ...any) {
+	l.Logger.Fatalln(l.convertArgs(v)...)
+}
+
+func (l *Logger) Fatalf(format string, v ...any) {
+	l.Logger.Fatalf(format, l.convertArgs(v)...)
+}
+
+func (l *Logger) Panic(v ...any) {
+	l.Logger.Panic(l.convertArgs(v)...)
+}
+
+func (l *Logger) Panicln(v ...any) {
+	l.Logger.Panicln(l.convertArgs(v)...)
+}
+
+func (l *Logger) Panicf(format string, v ...any) {
+	l.Logger.Panicf(format, l.convertArgs(v)...)
 }

--- a/go-print/logger.go
+++ b/go-print/logger.go
@@ -19,6 +19,8 @@ func NewLogger(pkgName string) *Logger {
 	}
 	logger.SetFlags(log.Ldate | log.Lmicroseconds | log.Lshortfile)
 
+	logger.formatter = &DefaultFormatter
+
 	return logger
 }
 
@@ -27,8 +29,8 @@ func (l *Logger) UseFormatter(formatter *Formatter) *Logger {
 	return l
 }
 
-func (l *Logger) UseGpFormatter() *Logger {
-	return l.UseFormatter(&DefaultFormatter)
+func (l *Logger) UseStdFormatter() *Logger {
+	return l.UseFormatter(nil)
 }
 
 func (l *Logger) convertArgs(v []any) []any {


### PR DESCRIPTION
When an object references itself, `gp.ToString` can lead to a `stack overflow` due to infinite recursion. This issue is resolved by implementing a maximum recursion limit and omitting container objects that referenced by duplicate pointer.