### PR TITLE
gp日志模块优化

### DIFF
--- a/go-print/goprint.go
+++ b/go-print/goprint.go
@@ -334,6 +334,13 @@ func (f *Formatter) funcReturnsTypeString(type_ reflect.Type) string {
 }
 
 func (f *Formatter) structToString(value reflect.Value, ctx gpfContext) string {
+	// fmt.Stringer interface
+	if value.CanInterface() {
+		if stringer, ok := value.Interface().(fmt.Stringer); ok {
+			return coloredString(stringer.String(), len(ctx.Indents), f.BracketColor, false)
+		}
+	}
+
 	type_ := value.Type()
 	var fields = make(map[int]reflect.StructField)
 	for i := 0; i < value.NumField(); i++ {

--- a/go-print/logger.go
+++ b/go-print/logger.go
@@ -1,6 +1,7 @@
 package gp
 
 import (
+	"fmt"
 	"log"
 	"os"
 )
@@ -42,38 +43,51 @@ func (l *Logger) convertArgs(v []any) []any {
 	return v
 }
 
+// region overrides
+
 func (l *Logger) Print(v ...any) {
-	l.Logger.Print(l.convertArgs(v)...)
+	l.Output(2, fmt.Sprint(l.convertArgs(v)...))
 }
 
 func (l *Logger) Println(v ...any) {
-	l.Logger.Println(l.convertArgs(v)...)
+	l.Output(2, fmt.Sprintln(l.convertArgs(v)...))
 }
 
 func (l *Logger) Printf(format string, v ...any) {
-	l.Logger.Printf(format, l.convertArgs(v)...)
+	l.Output(2, fmt.Sprintf(format, l.convertArgs(v)...))
 }
 
 func (l *Logger) Fatal(v ...any) {
-	l.Logger.Fatal(l.convertArgs(v)...)
+	l.Output(2, fmt.Sprint(l.convertArgs(v)...))
+	os.Exit(1)
 }
 
 func (l *Logger) Fatalln(v ...any) {
-	l.Logger.Fatalln(l.convertArgs(v)...)
+	l.Output(2, fmt.Sprintln(l.convertArgs(v)...))
+	os.Exit(1)
 }
 
 func (l *Logger) Fatalf(format string, v ...any) {
-	l.Logger.Fatalf(format, l.convertArgs(v)...)
+	l.Output(2, fmt.Sprintf(format, l.convertArgs(v)...))
+	os.Exit(1)
 }
 
 func (l *Logger) Panic(v ...any) {
-	l.Logger.Panic(l.convertArgs(v)...)
+	s := fmt.Sprint(l.convertArgs(v)...)
+	l.Output(2, s)
+	panic(s)
 }
 
 func (l *Logger) Panicln(v ...any) {
-	l.Logger.Panicln(l.convertArgs(v)...)
+	s := fmt.Sprintln(l.convertArgs(v)...)
+	l.Output(2, s)
+	panic(s)
 }
 
 func (l *Logger) Panicf(format string, v ...any) {
-	l.Logger.Panicf(format, l.convertArgs(v)...)
+	s := fmt.Sprintf(format, l.convertArgs(v)...)
+	l.Output(2, s)
+	panic(s)
 }
+
+// regionend

--- a/go-print/utils.go
+++ b/go-print/utils.go
@@ -30,3 +30,15 @@ func appendColoredString(sb *strings.Builder, str string, colorIdx int, useColor
 		sb.WriteString(str)
 	}
 }
+
+func coloredString(str string, colorIdx int, useColor bool, bold bool) string {
+	if useColor {
+		if bold {
+			return boldColors[colorIdx%len(boldColors)].Sprint(str)
+		} else {
+			return normalColors[colorIdx%len(normalColors)].Sprint(str)
+		}
+	} else {
+		return str
+	}
+}


### PR DESCRIPTION
- 如果结构体实现了 `.String()` 方法就直接调用它而不是gp模块自己转字符串
- 修复打印日志时行号不正确的问题